### PR TITLE
Add hook to synchronize tags to a remote system

### DIFF
--- a/modules/tags/add.php
+++ b/modules/tags/add.php
@@ -92,8 +92,8 @@ if ( $http->hasPostVariable('SaveButton' ) )
         $tag->updateModified();
 
         /* Extended Hook */
-        if ((eZPublishSDK::VERSION_MAJOR >= 4) && (eZPublishSDK::VERSION_MINOR >= 5))
-            $tag = ezpEvent::getInstance()->filter( 'tag/add', $tag );	
+        if (class_exists( 'ezpEvent', false ))
+	    $tag = ezpEvent::getInstance()->filter( 'tag/add', $tag );	
 
         $db->commit();
 

--- a/modules/tags/delete.php
+++ b/modules/tags/delete.php
@@ -48,7 +48,7 @@ else
         eZTagsObject::recursiveTagDelete( $tag );
 
         /* Extended Hook */
-        if ((eZPublishSDK::VERSION_MAJOR >= 4) && (eZPublishSDK::VERSION_MINOR >= 5))
+	if (class_exists( 'ezpEvent', false ))
             $tag = ezpEvent::getInstance()->filter( 'tag/delete', $tag );	
 
         $db->commit();

--- a/modules/tags/edit.php
+++ b/modules/tags/edit.php
@@ -82,7 +82,7 @@ if ( $http->hasPostVariable( 'SaveButton' ) )
         $tag->registerSearchObjects();
 
 	/* Extended Hook */
-        if ((eZPublishSDK::VERSION_MAJOR >= 4) && (eZPublishSDK::VERSION_MINOR >= 5))
+	if (class_exists( 'ezpEvent', false ))
             $tag = ezpEvent::getInstance()->filter( 'tag/edit', $tag );
 
         $db->commit();

--- a/modules/tags/merge.php
+++ b/modules/tags/merge.php
@@ -123,7 +123,7 @@ else
             $mainTag->updateModified();
 
             /* Extended Hook */
-            if ((eZPublishSDK::VERSION_MAJOR >= 4) && (eZPublishSDK::VERSION_MINOR >= 5))
+	if (class_exists( 'ezpEvent', false ))
                 $tag = ezpEvent::getInstance()->filter( 'tag/merge', array('tag'=>$tag,'mainTag'=>$mainTag ));
 
             $db->commit();


### PR DESCRIPTION
Hi eZ Tags team,

We are making an extension on top of eZ Tags. We would know if you can accept this enhancement.
This pull request just add 4 dispatch events, which allow us to extends your extension behaviour.

We have to establish a tags synchronisazion with a remote system.

Thanks for your feedback.

Sébastien
