### PR TITLE
Fixed a typo in eZTagsObject

### DIFF
--- a/classes/eztagsobject.php
+++ b/classes/eztagsobject.php
@@ -359,9 +359,9 @@ class eZTagsObject extends eZPersistentObject
     {
         $pathArray = explode( '/', trim( $this->PathString, '/' ) );
 
-        if ( $this->MainNodeID > 0 )
+        if ( $this->MainTagID > 0 )
         {
-            array_push( $pathArray, $this->MainNodeID );
+            array_push( $pathArray, $this->MainTagID );
         }
 
         if ( !empty( $pathArray ) )


### PR DESCRIPTION
Hi,
I got a few notices while running a script to create tags (unknown property `MainNodeID`). I guess it was a copy and paste mistake and replaced it with `MainTagID`.
