### PR TITLE
Fixed a PHP notice in list fetch function

### DIFF
--- a/classes/eztagsobject.php
+++ b/classes/eztagsobject.php
@@ -666,10 +666,14 @@ class eZTagsObject extends eZPersistentObject
             $fetchParams['depth'] = array( $sqlDepthOperator, $depth );
         }
 
-        $limits = array( 'offset' => $offset );
-
+        $limits = null;
         if ( $limit > 0 )
-            $limits['limit'] = $limit;
+        {
+            $limits = array(
+                'offset' => $offset,
+                'limit' => $limit,
+            );
+        }
 
         $sorts = array();
         if ( !empty( $sortBy ) )


### PR DESCRIPTION
when no limit was specified, an offset was however set resulting in a php notice in eZPersistentObject
Offset is now set only if limit is set
