### PR TITLE
Fixed: No children in root tag, even if it has

### DIFF
--- a/design/admin2/templates/tags/dashboard/latest_tags.tpl
+++ b/design/admin2/templates/tags/dashboard/latest_tags.tpl
@@ -10,17 +10,17 @@
             <th>{"Parent tag name"|i18n( "extension/eztags/tags/dashboard" )}</th>
             <th>{"Modified"|i18n( "extension/eztags/tags/dashboard" )}</th>
         </tr>
-        {foreach $latest_tags as $tag sequence array( 'bglight', 'bgdark' ) as $sequence}
+        {foreach $latest_tags as $latest_tag sequence array( 'bglight', 'bgdark' ) as $sequence}
             <tr>
-                <td><img class="transparent-png-icon" src={concat( 'tag_icons/small/', $tag.icon )|ezimage} alt="{$tag.keyword|wash}" /></td>
-                <td>{$tag.id}</td>
-                <td><a href={concat( 'tags/id/', $tag.id )|ezurl}>{$tag.keyword|wash}</a></td>
-                {if $tag.parent}
-                    <td><a href={concat( 'tags/id/', $tag.parent.id )|ezurl}>{$tag.parent.keyword|wash}</a></td>
+                <td><img class="transparent-png-icon" src={concat( 'tag_icons/small/', $latest_tag.icon )|ezimage} alt="{$latest_tag.keyword|wash}" /></td>
+                <td>{$latest_tag.id}</td>
+                <td><a href={concat( 'tags/id/', $latest_tag.id )|ezurl}>{$latest_tag.keyword|wash}</a></td>
+                {if $latest_tag.parent}
+                    <td><a href={concat( 'tags/id/', $latest_tag.parent.id )|ezurl}>{$latest_tag.parent.keyword|wash}</a></td>
                 {else}
                     <td>{"No parent"|i18n( "extension/eztags/tags/dashboard" )}</td>
                 {/if}
-                <td>{$tag.modified|datetime( 'custom', '%d.%m.%Y %H:%i' )}</td>
+                <td>{$latest_tag.modified|datetime( 'custom', '%d.%m.%Y %H:%i' )}</td>
             </tr>
         {/foreach}
     </tbody>


### PR DESCRIPTION
hi. i changed the variable name in latest_tag block. 
in dashboard view, no tag variable is set from php code. But it seems to be set when looping the latest tags. 

Because of that, children tags template always had $tag set, and normally that $tag object will be the last added. 

So, to avoid this conflict, i decided to change that var name in the loop. 

Please let me know if there is a better way to doing. 

Cheers.
