### PR TITLE
Hide tags (multilanguage version)

### DIFF
--- a/classes/ezfsolrdocumentfieldeztags.php
+++ b/classes/ezfsolrdocumentfieldeztags.php
@@ -35,7 +35,9 @@ class ezfSolrDocumentFieldeZTags extends ezfSolrDocumentFieldBase
 
         $tagIDs = array();
         $keywords = array();
-        $indexSynonyms = eZINI::instance( 'eztags.ini' )->variable( 'SearchSettings', 'IndexSynonyms' ) === 'enabled';
+        $ini = eZINI::instance( 'eztags.ini' );
+        $indexSynonyms = $ini->variable( 'SearchSettings', 'IndexSynonyms' ) === 'enabled';
+        $indexHidden = $ini->variable( 'SearchSettings', 'IndexHidden' ) === 'enabled';
 
         $tags = $objectAttributeContent->attribute( 'tags' );
         if ( is_array( $tags ) )
@@ -46,7 +48,7 @@ class ezfSolrDocumentFieldeZTags extends ezfSolrDocumentFieldBase
                 if ( !$indexSynonyms && $tag->isSynonym() )
                     $tag = $tag->getMainTag();
 
-                if ( $tag instanceof eZTagsObject )
+                if ( $tag instanceof eZTagsObject && ( $indexHidden || $tag->isVisible() ) )
                 {
                     $tagIDs[] = (int) $tag->attribute( 'id' );
                     $keywords[] = $tag->attribute( 'keyword' );

--- a/classes/ezjsctagschildren.php
+++ b/classes/ezjsctagschildren.php
@@ -68,6 +68,7 @@ class ezjscTagsChildren extends ezjscServerFunctions
             $tagArray['id'] = $child->attribute( 'id' );
             $tagArray['keyword'] = htmlspecialchars( $child->attribute( 'keyword' ), ENT_QUOTES );
             $tagArray['modified'] = $child->attribute( 'modified' );
+            $tagArray['hidden'] = $child->attribute( 'hidden' );
 
             $tagArray['translations'] = array();
             foreach ( $child->getTranslations() as $translation )

--- a/classes/eztagsobject.php
+++ b/classes/eztagsobject.php
@@ -786,6 +786,12 @@ class eZTagsObject extends eZPersistentObject
             $customConds .= " AND " . eZContentLanguage::sqlFilter( 'eztags_keyword', 'eztags' ) . " ";
         }
 
+        $ignoreVisibility = eZINI::instance( 'eztags.ini' )->variable( 'VisibilitySettings', 'ShowHiddenTags' ) === 'enabled';
+        if( !$ignoreVisibility )
+        {
+            $customConds .= " AND eztags.hidden = 0 ";
+        }
+
         return $customConds;
     }
 

--- a/classes/eztagsobject.php
+++ b/classes/eztagsobject.php
@@ -8,6 +8,9 @@
  */
 class eZTagsObject extends eZPersistentObject
 {
+    const VISIBILITY_HIDDEN = 1;
+    const VISIBILITY_INVISIBLE = 2;
+
     /**
      * Constructor
      *
@@ -73,7 +76,11 @@ class eZTagsObject extends eZPersistentObject
                                                       'language_mask'    => array( 'name'     => 'LanguageMask',
                                                                                    'datatype' => 'integer',
                                                                                    'default'  => 0,
-                                                                                   'required' => false ) ),
+                                                                                   'required' => false ),
+                                                      'hidden'           => array( 'name' => "Hidden",
+                                                                                   'datatype' => 'integer',
+                                                                                   'default' => 0,
+                                                                                   'required' => false ), ),
                       'function_attributes' => array( 'parent'                    => 'getParent',
                                                       'children'                  => 'getChildren',
                                                       'children_count'            => 'getChildrenCount',
@@ -85,6 +92,9 @@ class eZTagsObject extends eZPersistentObject
                                                       'synonyms'                  => 'getSynonyms',
                                                       'synonyms_count'            => 'getSynonymsCount',
                                                       'is_synonym'                => 'isSynonym',
+                                                      'is_visible'                => 'isVisible',
+                                                      'is_hidden'                 => 'isHidden',
+                                                      'is_invisible'              => 'isInvisible',
                                                       'icon'                      => 'getIcon',
                                                       'url'                       => 'getUrl',
                                                       'path'                      => 'getPath',
@@ -354,6 +364,65 @@ class eZTagsObject extends eZPersistentObject
     public function isSynonym()
     {
         return $this->attribute( 'main_tag_id' ) > 0;
+    }
+
+    /**
+     * Tells wether tag object is visible
+     * @return boolean
+     */
+    function isVisible()
+    {
+        return !$this->isHidden() && !$this->isInvisible();
+    }
+
+
+    /**
+     * Tells wether tag object is hidden
+     * @return boolean
+     */
+    function isHidden()
+    {
+        return ( intval( $this->attribute( 'hidden' ) ) & self::VISIBILITY_HIDDEN ) === self::VISIBILITY_HIDDEN;
+    }
+
+
+    /**
+     * Tells wether tag object is invisible (under a hidden tag)
+     * @return boolean
+     */
+    function isInvisible()
+    {
+        return ( intval( $this->attribute( 'hidden' ) ) & self::VISIBILITY_INVISIBLE ) === self::VISIBILITY_INVISIBLE;
+    }
+
+    /**
+     * Hide/unhide tag. Keeps eventual invisibility
+     */
+    function setHidden( $hidden )
+    {
+        if( $hidden )
+        {
+            $this->setAttribute( 'hidden', intval( $this->attribute( 'hidden' ) ) | self::VISIBILITY_HIDDEN );
+        }
+        else
+        {
+            $this->setAttribute( 'hidden', intval( $this->attribute( 'hidden' ) ) & ~self::VISIBILITY_HIDDEN );
+        }
+    }
+
+    /**
+     * Set visible / invisible. Keeps eventual hide
+     */
+    function setInvisible( $invisible )
+    {
+        if( $invisible )
+        {
+            $this->setAttribute( 'hidden', intval( $this->attribute( 'hidden' ) ) | self::VISIBILITY_INVISIBLE );
+        }
+        else
+        {
+            $this->setAttribute( 'hidden', intval( $this->attribute( 'hidden' ) ) & ~self::VISIBILITY_INVISIBLE );
+        }
     }
 
     /**

--- a/datatypes/eztags/eztags.php
+++ b/datatypes/eztags/eztags.php
@@ -487,6 +487,12 @@ class eZTags
             'path_string'      => $parentPathString,
             'main_language_id' => $languageID,
             'language_mask'    => $languageID + $alwaysAvailable ), $locale );
+
+        $parentTag = $tagObject->getParent( true );
+        if( $parentTag instanceof eZTagsObject && !$parentTag->isVisible() )
+        {
+            $tagObject->setInvisible( true );
+        }
         $tagObject->store();
 
         $tagObject->setAttribute( 'path_string', $tagObject->attribute( 'path_string' ) . $tagObject->attribute( 'id' ) . '/' );
@@ -514,7 +520,7 @@ class eZTags
                 'tag/add',
                 array(
                     'tag' => $tagObject,
-                    'parentTag' => $tagObject->getParent( true )
+                    'parentTag' => $parentTag
                 )
             );
         }

--- a/datatypes/eztags/eztagstype.php
+++ b/datatypes/eztags/eztagstype.php
@@ -344,7 +344,9 @@ class eZTagsType extends eZDataType
         if ( !$eZTags instanceof eZTags )
             return '';
 
-        $indexSynonyms = eZINI::instance( 'eztags.ini' )->variable( 'SearchSettings', 'IndexSynonyms' ) === 'enabled';
+        $ini = eZINI::instance( 'eztags.ini' );
+        $indexSynonyms = $ini->variable( 'SearchSettings', 'IndexSynonyms' ) === 'enabled';
+        $indexHidden = $ini->variable( 'SearchSettings', 'IndexHidden' ) === 'enabled';
 
         $keywords = array();
         $tags = $eZTags->attribute( 'tags' );
@@ -355,7 +357,7 @@ class eZTagsType extends eZDataType
             if ( !$indexSynonyms && $tag->isSynonym() )
                 $tag = $tag->getMainTag();
 
-            if ( $tag instanceof eZTagsObject )
+            if ( $tag instanceof eZTagsObject && ( $indexHidden || $tag->isVisible() ) )
                 $keywords[] = $tag->attribute( 'keyword' );
         }
 

--- a/design/admin2/javascript/jquery.eztagschildren.js
+++ b/design/admin2/javascript/jquery.eztagschildren.js
@@ -98,9 +98,9 @@
 
         var tagVisibility = function( cell, record, column, data ) {
             var html = '';
-            if( record.getData( 'hidden' ) & 1 === 1 ) {
+            if( parseInt( record.getData( 'hidden' ) ) & 1 ) {
                 html = settings.i18n.hidden;
-            } else if( record.getData( 'hidden' ) & 2 === 2 ) {
+            } else if( parseInt( record.getData( 'hidden' ) ) & 2 ) {
                 html = settings.i18n.invisible;
             } else {
                 html = settings.i18n.visible;

--- a/design/admin2/javascript/jquery.eztagschildren.js
+++ b/design/admin2/javascript/jquery.eztagschildren.js
@@ -96,6 +96,19 @@
             cell.innerHTML = html;
         }
 
+        var tagVisibility = function( cell, record, column, data ) {
+            var html = '';
+            if( record.getData( 'hidden' ) & 1 === 1 ) {
+                html = settings.i18n.hidden;
+            } else if( record.getData( 'hidden' ) & 2 === 2 ) {
+                html = settings.i18n.invisible;
+            } else {
+                html = settings.i18n.visible;
+            }
+
+            cell.innerHTML = html;
+        }
+
         /* Paginator definition */
 
         var dataTablePaginator = new YAHOO.widget.Paginator({
@@ -360,7 +373,8 @@
             { key: 'id', parser: 'number' },
             { key: 'keyword', parser: 'string' },
             { key: 'modified', parser: timeStampYuiParser },
-            { key: 'translations' }
+            { key: 'translations' },
+            { key: 'hidden' }
         ];
 
         var dataSource = new YAHOO.util.XHRDataSource(settings.urls.data, {
@@ -384,6 +398,7 @@
             { key: 'id', label: settings.i18n.id, sortable: true, resizeable: true, formatter: 'text' },
             { key: 'keyword', label: settings.i18n.tag_name, sortable: true, resizeable: true, formatter: tagName },
             { key: 'translations', label: settings.i18n.translations, sortable: false, resizeable: true, formatter: tagTranslations },
+            { key: 'hidden', label: settings.i18n.visibility, sortable: true, resizeable: true, formatter: tagVisibility },
             { key: 'modified', label: settings.i18n.modified, sortable: true, resizeable: true, formatter: 'date' }
         ];
 

--- a/design/admin2/templates/eztags_children.tpl
+++ b/design/admin2/templates/eztags_children.tpl
@@ -50,6 +50,7 @@
                         <th class="tight">&nbsp;</th>
                         <th>{"ID"|i18n( "extension/eztags/tags/view" )}</th>
                         <th>{"Tag name"|i18n( "extension/eztags/tags/view" )}</th>
+                        <th>{"Visibility"|i18n( "extension/eztags/tags/edit" )}</th>
                         <th>{"Modified"|i18n( "extension/eztags/tags/view" )}</th>
                         <th class="tight">&nbsp;</th>
                     </tr>
@@ -58,6 +59,15 @@
                             <td><img class="transparent-png-icon" src="{$child_tag.icon|tag_icon}" alt="{$child_tag.keyword|wash}" /></td>
                             <td>{$child_tag.id}</td>
                             <td><a href={concat( '/tags/id/', $child_tag.id )|ezurl}>{$child_tag.keyword|wash}{cond( $child_tag.synonyms_count|gt(0), concat( ' (+', $child_tag.synonyms_count, ')' ), '' )}</a></td>
+                            <td>
+                                {if $child_tag.is_visible}
+                                    {"Visible"|i18n( "extension/eztags/tags/edit" )}
+                                {elseif $child_tag.is_hidden}
+                                    {"Hidden"|i18n( "extension/eztags/tags/edit" )}
+                                {else}
+                                    {"Hidden by superior"|i18n( "extension/eztags/tags/edit" )}
+                                {/if}
+                            </td>
                             <td>{$child_tag.modified|datetime( 'custom', '%d.%m.%Y %H:%i' )}</td>
                             <td><a href={concat( '/tags/edit/', $child_tag.id )|ezurl}><img src={'edit.gif'|ezimage} alt="Edit" /></a></td>
                         </tr>

--- a/design/admin2/templates/eztags_children_yui.tpl
+++ b/design/admin2/templates/eztags_children_yui.tpl
@@ -43,6 +43,10 @@
                 *}tag_name: "{'Tag name'|i18n( 'extension/eztags/tags/view' )|wash( javascript )}",{*
                 *}translations: "{'Tag translations'|i18n( 'extension/eztags/tags/view' )|wash( javascript )}",{*
                 *}modified: "{'Modified'|i18n( 'extension/eztags/tags/view' )|wash( javascript )}",{*
+                *}visibility: "{'Visibility'|i18n( "extension/eztags/tags/edit" )|wash( javascript )}",{*
+                *}hidden: "{'Hidden'|i18n( "extension/eztags/tags/edit" )|wash( javascript )}",{*
+                *}visible: "{'Visible'|i18n( "extension/eztags/tags/edit" )|wash( javascript )}",{*
+                *}invisible: "{'Hidden by superior'|i18n( "extension/eztags/tags/edit" )|wash( javascript )}",{*
                 *}first_page: "&laquo;&nbsp;{'first'|i18n( 'extension/eztags/tags/view' )|wash( javascript )}",{*
                 *}last_page: "{'last'|i18n( 'extension/eztags/tags/view' )|wash( javascript )}&nbsp;&raquo;",{*
                 *}previous_page: "&lsaquo;&nbsp;{'prev'|i18n( 'extension/eztags/tags/view' )|wash( javascript )}",{*

--- a/design/admin2/templates/parts/tags_view_control_bar.tpl
+++ b/design/admin2/templates/parts/tags_view_control_bar.tpl
@@ -29,9 +29,22 @@
                 </form>
             {/if}
             {if fetch( user, has_access_to, hash( module, tags, function, makesynonym ) )}
-                <form name="tagmakesynonym" id="tagmakesynonym" style="float:left;" enctype="multipart/form-data" method="post" action={concat( 'tags/makesynonym/', $tag.id )|ezurl}>
+                <form name="tagmakesynonym" id="tagmakesynonym" style="float:left; margin-right:10px;" enctype="multipart/form-data" method="post" action={concat( 'tags/makesynonym/', $tag.id )|ezurl}>
                     <input class="button" type="submit" name="SubmitButton" value="{"Convert to synonym"|i18n( "extension/eztags/tags/view" )}" />
                 </form>
+            {/if}
+            {if fetch( user, has_access_to, hash( module, tags, function, hide ) )}
+                {if $tag.is_hidden}
+                <form name="taghide" id="taghide" style="float:left;" enctype="multipart/form-data" method="post" action={concat( 'tags/hide/', $tag.id, '/unhide' )|ezurl}>
+                    <input class="button" type="submit" name="SubmitButton" value="{"Unhide"|i18n( "extension/eztags/tags/edit" )}" />
+                </form>
+                {elseif $tag.is_visible}
+                <form name="taghide" id="taghide" style="float:left;" enctype="multipart/form-data" method="post" action={concat( 'tags/hide/', $tag.id, '/hide' )|ezurl}>
+                    <input class="button" type="submit" name="SubmitButton" value="{"Hide"|i18n( "extension/eztags/tags/edit" )}" />
+                </form>
+                {else}
+                <input class="button-disabled" type="submit" name="SubmitButton" value="{"Unhide"|i18n( "extension/eztags/tags/edit" )}" disabled="disabled" />
+                {/if}
             {/if}
         </div>
     </div>

--- a/design/admin2/templates/popupmenu/popup_tag_menu.tpl
+++ b/design/admin2/templates/popupmenu/popup_tag_menu.tpl
@@ -4,7 +4,8 @@
      $tags_merge_access = fetch( user, has_access_to, hash( module, tags, function, merge ) )
      $tags_add_synonym_access = fetch( user, has_access_to, hash( module, tags, function, addsynonym ) )
      $tags_make_synonym_access = fetch( user, has_access_to, hash( module, tags, function, makesynonym ) )
-     $show_full_menu = or( $tags_add_access, $tags_edit_access, $tags_delete_access, $tags_merge_access, $tags_add_synonym_access, $tags_make_synonym_access )}
+     $tags_hide_access = fetch( user, has_access_to, hash( module, tags, function, hide ) )
+     $show_full_menu = or( $tags_add_access, $tags_edit_access, $tags_delete_access, $tags_merge_access, $tags_add_synonym_access, $tags_make_synonym_access, $tags_hide_access )}
 
 {if $show_full_menu}
     <script type="text/javascript">
@@ -37,6 +38,10 @@
 
         {if $tags_make_synonym_access}
             menuArray['TagMenu']['elements']['make-synonym-tag'] = {ldelim} 'url': {"/tags/makesynonym/%tagID%"|ezurl} {rdelim};
+        {/if}
+        
+        {if $tags_hide_access}
+            menuArray['TagMenu']['elements']['hide-tag'] = {ldelim} 'url': {"/tags/hide/%tagID%"|ezurl} {rdelim};
         {/if}
     </script>
 {/if}
@@ -72,6 +77,10 @@
         {/if}
         {if $tags_make_synonym_access}
             <a id="make-synonym-tag" href="#" onmouseover="ezpopmenu_mouseOver( 'TagMenu' )">{"Convert to synonym"|i18n( "extension/eztags/tags/treemenu" )}</a>
+        {/if}
+        <hr />
+        {if $tags_hide_access}
+            <a id="hide-tag" href="#" onmouseover="ezpopmenu_mouseOver( 'TagMenu' )">{"Hide/Unhide"|i18n( "extension/eztags/tags/edit" )}</a>
         {/if}
     </div>
 {/if}

--- a/design/admin2/templates/tags/view.tpl
+++ b/design/admin2/templates/tags/view.tpl
@@ -7,6 +7,11 @@
             {else}
                 {'Synonym'|i18n( 'extension/eztags/tags/view' )}: {$tag.keyword|wash} ({'Main tag'|i18n( 'extension/eztags/tags/view' )}: <a href={concat( 'tags/id/', $tag.main_tag_id )|ezurl}>{$tag.main_tag.keyword|wash}</a>)
             {/if}
+            {if $tag.is_hidden}
+                ({'Hidden'|i18n('extension/eztags/tags/edit')})
+            {elseif $tag.is_invisible}
+                ({'Hidden by superior'|i18n('extension/eztags/tags/edit')})
+            {/if}
         </h1>
         <div class="header-mainline"></div>
     </div>

--- a/design/admin2/templates/tagsstructuremenu/tags_structure_menu_dynamic.tpl
+++ b/design/admin2/templates/tagsstructuremenu/tags_structure_menu_dynamic.tpl
@@ -32,7 +32,8 @@ var TagsStructureMenuParams = {ldelim}{*
         *}"keyword":"{"Top level tags"|i18n('extension/eztags/tags/treemenu')|wash(javascript)}",{*
         *}"url":{'tags/dashboard'|ezurl},{*
         *}"icon":"{ezini( 'Icons', 'Default', 'eztags.ini' )|tag_icon}",{*
-        *}"modified":currentDate{rdelim};
+        *}"modified":currentDate,{*
+        *}"hidden":0{rdelim};
 
     document.writeln( '<ul id="content_tree_menu">' );
     document.writeln( treeMenu_0.generateEntry( rootTag, false, true ) );

--- a/design/standard/javascript/tagsstructuremenu.js
+++ b/design/standard/javascript/tagsstructuremenu.js
@@ -143,13 +143,23 @@ function TagsStructureMenu( params, attribute_id )
             html += ' title="' + params.tag_id_string + ': ' + item.id + ', ' + params.parent_tag_id_string + ': ' + item.parent_id + '"';
         }
 
+        var visibilityClass = 'node-name-normal';
+        if ( item.hidden & 1 === 1 )
+        {
+            visibilityClass = 'node-name-hidden';
+        }
+        else if ( item.hidden & 2 === 2 )
+        {
+            visibilityClass = 'node-name-hiddenbyparent';
+        }
+
         if ( !this.modal )
         {
-            html += '><span class="node-name-normal' + ( ( item.subtree_limitations_count > 0 ) ? ' disabled' : '' ) + '">' + item.keyword;
+            html += '><span class="' + visibilityClass + ( ( item.subtree_limitations_count > 0 ) ? ' disabled' : '' ) + '">' + item.keyword;
         }
         else
         {
-            html += '><span class="node-name-normal">' + item.keyword;
+            html += '><span class="' + visibilityClass + '">' + item.keyword;
         }
 
         if( item.synonyms_count > 0 )

--- a/design/standard/javascript/tagsstructuremenu.js
+++ b/design/standard/javascript/tagsstructuremenu.js
@@ -144,11 +144,11 @@ function TagsStructureMenu( params, attribute_id )
         }
 
         var visibilityClass = 'node-name-normal';
-        if ( item.hidden & 1 === 1 )
+        if ( parseInt( item.hidden ) & 1 )
         {
             visibilityClass = 'node-name-hidden';
         }
-        else if ( item.hidden & 2 === 2 )
+        else if ( parseInt( item.hidden ) & 2 )
         {
             visibilityClass = 'node-name-hiddenbyparent';
         }

--- a/design/standard/templates/ezjsctemplate/tree_menu.tpl
+++ b/design/standard/templates/ezjsctemplate/tree_menu.tpl
@@ -15,7 +15,8 @@ var treeMenu_{$attribute_id};
             *}"keyword":"{$root_tag.keyword|wash(javascript)}",{*
             *}"url":{concat('tags/id/', $root_tag.id)|ezurl},{*
             *}"icon":"{$root_tag.icon|tag_icon}",{*
-            *}"modified":{$root_tag.modified}{rdelim};
+            *}"modified":{$root_tag.modified},{*
+            *}"hidden":{$root_tag.hidden}{rdelim};
     {else}
         var rootTag = {ldelim}{*
             *}"id":0,{*
@@ -24,7 +25,8 @@ var treeMenu_{$attribute_id};
             *}"keyword":"{"Top level tags"|i18n('extension/eztags/tags/treemenu')|wash(javascript)}",{*
             *}"url":{'tags/dashboard'|ezurl},{*
             *}"icon":"{ezini( 'Icons', 'Default', 'eztags.ini' )|tag_icon}",{*
-            *}"modified":currentDate{rdelim};
+            *}"modified":currentDate,{*
+            *}"hidden":0{rdelim};
     {/if}
 
     document.writeln( '<ul class="content_tree_menu">' );

--- a/modules/tags/add.php
+++ b/modules/tags/add.php
@@ -108,6 +108,11 @@ if ( $http->hasPostVariable('SaveButton' ) )
                                         'path_string'      => $parentTag instanceof eZTagsObject ? $parentTag->attribute( 'path_string' ) : '/',
                                         'main_language_id' => $language->attribute( 'id' ),
                                         'language_mask'    => $languageMask ), $language->attribute( 'locale' ) );
+
+        if( $parentTag instanceof eZTagsObject && !$parentTag->isVisible() )
+        {
+            $tag->setInvisible( true );
+        }
         $tag->store();
 
         $translation = new eZTagsKeyword( array( 'keyword_id'  => $tag->attribute( 'id' ),

--- a/modules/tags/addsynonym.php
+++ b/modules/tags/addsynonym.php
@@ -76,6 +76,10 @@ if ( $http->hasPostVariable( 'SaveButton' ) )
                                         'path_string'      => $parentTag instanceof eZTagsObject ? $parentTag->attribute( 'path_string' ) : '/',
                                         'main_language_id' => $language->attribute( 'id' ),
                                         'language_mask'    => $languageMask ), $language->attribute( 'locale' ) );
+        if( !$mainTag->isVisible() )
+        {
+            $tag->setInvisible( true );
+        }
         $tag->store();
 
         $translation = new eZTagsKeyword( array( 'keyword_id'  => $tag->attribute( 'id' ),

--- a/modules/tags/edit.php
+++ b/modules/tags/edit.php
@@ -121,6 +121,7 @@ if ( $http->hasPostVariable( 'SaveButton' ) )
 
         $oldParentDepth = $tag->attribute( 'depth' ) - 1;
         $newParentDepth = $newParentTag instanceof eZTagsObject ? $newParentTag->attribute( 'depth' ) : 0;
+        $newParentVisible = $newParentTag instanceof eZTagsObject ? $newParentTag->isVisible() : true;
 
         if ( $oldParentDepth != $newParentDepth )
             $updateDepth = true;
@@ -132,10 +133,19 @@ if ( $http->hasPostVariable( 'SaveButton' ) )
             if ( $oldParentTag instanceof eZTagsObject )
                 $oldParentTag->updateModified();
 
+            if( !$newParentVisible )
+            {
+                $tag->setInvisible( true );
+            }
+
             $synonyms = $tag->getSynonyms( true );
             foreach ( $synonyms as $synonym )
             {
                 $synonym->setAttribute( 'parent_id', $newParentID );
+                if( !$newParentVisible )
+                {
+                    $synonym->setInvisible( true );
+                }
                 $synonym->store();
             }
 

--- a/modules/tags/edit.php
+++ b/modules/tags/edit.php
@@ -133,19 +133,13 @@ if ( $http->hasPostVariable( 'SaveButton' ) )
             if ( $oldParentTag instanceof eZTagsObject )
                 $oldParentTag->updateModified();
 
-            if( !$newParentVisible )
-            {
-                $tag->setInvisible( true );
-            }
+            $tag->setInvisible( !$newParentVisible );
 
             $synonyms = $tag->getSynonyms( true );
             foreach ( $synonyms as $synonym )
             {
                 $synonym->setAttribute( 'parent_id', $newParentID );
-                if( !$newParentVisible )
-                {
-                    $synonym->setInvisible( true );
-                }
+                $synonym->setInvisible( !$tag->isVisible() );
                 $synonym->store();
             }
 

--- a/modules/tags/hide.php
+++ b/modules/tags/hide.php
@@ -1,0 +1,76 @@
+<?php
+
+/** @var eZModule $Module */
+/** @var array $Params */
+
+$http = eZHTTPTool::instance();
+
+$tagID = (int) $Params['TagID'];
+$action = $Params['Action'];
+
+if ( $tagID <= 0 )
+{
+    return $Module->handleError( eZError::KERNEL_NOT_FOUND, 'kernel' );
+}
+
+$tag = eZTagsObject::fetchWithMainTranslation( $tagID );
+if ( !$tag instanceof eZTagsObject )
+    return $Module->handleError( eZError::KERNEL_NOT_FOUND, 'kernel' );
+
+if( !trim( $action ) )
+{
+    if( $tag->isHidden() )
+    {
+        $action = 'unhide';
+    }
+    else
+    {
+        $action = 'hide';
+    }
+}
+
+if( !in_array( $action, array( 'hide', 'unhide' ) ) )
+{
+    return $Module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
+}
+
+if ( $tag->attribute( 'main_tag_id' ) != 0 )
+    return $Module->redirectToView( 'hide', array( $tag->attribute( 'main_tag_id' ), $action ) );
+
+$doHide = $action === 'hide';
+
+$db = eZDB::instance();
+$db->begin();
+$tag->setHidden( $doHide );
+$tag->updateModified();
+$tag->store();
+
+//hide synonyms
+$synonyms = $tag->getSynonyms();
+foreach( $synonyms as $synonym )
+{
+    $synonym->setInvisible( $doHide );
+    $synonym->updateModified();
+    $synonym->store();
+}
+
+//hide descendant tags
+$bitwiseOperator = $doHide ? '|' : '& ~';
+$sql = 'UPDATE eztags
+			SET hidden = hidden' . $bitwiseOperator . eZTagsObject::VISIBILITY_INVISIBLE .',
+				modified = ' . time() . '
+			WHERE path_string LIKE "' . $tag->attribute( 'path_string' ) . '%"';
+$db->query( $sql );
+
+$db->commit();
+
+/* Extended Hook */
+if ( class_exists( 'ezpEvent', false ) )
+{
+    $eventName = $doHide ? 'tag/hide' : 'tag/show';
+    ezpEvent::getInstance()->filter( $eventName, $tag );
+}
+
+
+$redirectURI = $http->hasPostVariable( 'RedirectURI' ) ? $http->postVariable( 'RedirectURI' ) : $http->sessionVariable( 'LastAccessesURI', '/' );
+$Module->redirectTo( $redirectURI );

--- a/modules/tags/makesynonym.php
+++ b/modules/tags/makesynonym.php
@@ -66,10 +66,7 @@ if ( $http->hasPostVariable( 'SaveButton' ) && $convertAllowed )
         {
             $synonym->setAttribute( 'parent_id', $mainTag->attribute( 'parent_id' ) );
             $synonym->setAttribute( 'main_tag_id', $mainTag->attribute( 'id' ) );
-            if( !$mainTag->isVisible() )
-            {
-                $synonym->setInvisible( true );
-            }
+            $synonym->setInvisible( !$mainTag->isVisible() );
             $synonym->store();
         }
 
@@ -78,10 +75,7 @@ if ( $http->hasPostVariable( 'SaveButton' ) && $convertAllowed )
 
         //synonyms can't be hidden, they can only be invisible if their main tag's hidden
         $tag->setHidden( false );
-        if( !$mainTag->isVisible() )
-        {
-            $tag->setInvisible( true );
-        }
+        $tag->setInvisible( !$mainTag->isVisible() );
 
         $tag->store();
 

--- a/modules/tags/makesynonym.php
+++ b/modules/tags/makesynonym.php
@@ -66,11 +66,23 @@ if ( $http->hasPostVariable( 'SaveButton' ) && $convertAllowed )
         {
             $synonym->setAttribute( 'parent_id', $mainTag->attribute( 'parent_id' ) );
             $synonym->setAttribute( 'main_tag_id', $mainTag->attribute( 'id' ) );
+            if( !$mainTag->isVisible() )
+            {
+                $synonym->setInvisible( true );
+            }
             $synonym->store();
         }
 
         $tag->setAttribute( 'parent_id', $mainTag->attribute( 'parent_id' ) );
         $tag->setAttribute( 'main_tag_id', $mainTag->attribute( 'id' ) );
+
+        //synonyms can't be hidden, they can only be invisible if their main tag's hidden
+        $tag->setHidden( false );
+        if( !$mainTag->isVisible() )
+        {
+            $tag->setInvisible( true );
+        }
+
         $tag->store();
 
         if ( $updatePathString )

--- a/modules/tags/module.php
+++ b/modules/tags/module.php
@@ -104,6 +104,12 @@ $ViewList['search'] = array(
     'params'                  => array(),
     'unordered_params'        => array( 'offset' => 'Offset' ) );
 
+$ViewList['hide'] = array(
+    'functions'               => array( 'hide' ),
+    'script'                  => 'hide.php',
+    'default_navigation_part' => 'eztagsnavigationpart',
+    'params'                  => array( 'TagID', 'Action' ) );
+
 $TagID = array(
     'name'      => 'Tag',
     'values'    => array(),
@@ -128,5 +134,6 @@ $FunctionList['deletesynonym'] = array();
 $FunctionList['makesynonym']   = array();
 $FunctionList['merge']         = array();
 $FunctionList['search']        = array();
+$FunctionList['hide']          = array();
 
 ?>

--- a/modules/tags/movetags.php
+++ b/modules/tags/movetags.php
@@ -81,23 +81,17 @@ if ( empty( $error ) && $http->hasPostVariable( 'SaveButton' ) )
         if ( $oldParentTag instanceof eZTagsObject )
             $oldParentTag->updateModified();
 
+        $tag->setAttribute( 'parent_id', $newParentID );
+        $tag->setInvisible( !$newParentVisible );
+        $tag->store();
+
         $synonyms = $tag->getSynonyms( true );
         foreach ( $synonyms as $synonym )
         {
             $synonym->setAttribute( 'parent_id', $newParentID );
-            if( !$newParentVisible )
-            {
-                $synonym->setInvisible( true );
-            }
+            $synonym->setInvisible( !$tag->isVisible() );
             $synonym->store();
         }
-
-        $tag->setAttribute( 'parent_id', $newParentID );
-        if( !$newParentVisible )
-        {
-            $tag->setInvisible( true );
-        }
-        $tag->store();
 
         /* Extended Hook */
         if ( class_exists( 'ezpEvent', false ) )

--- a/modules/tags/movetags.php
+++ b/modules/tags/movetags.php
@@ -72,6 +72,7 @@ if ( empty( $error ) && $http->hasPostVariable( 'SaveButton' ) )
 
         $oldParentDepth = $tag->attribute( 'depth' ) - 1;
         $newParentDepth = $newParentTag instanceof eZTagsObject ? $newParentTag->attribute( 'depth' ) : 0;
+        $newParentVisible = $newParentTag instanceof eZTagsObject ? $newParentTag->isVisible() : true;
 
         if ( $oldParentDepth != $newParentDepth )
             $updateDepth = true;
@@ -84,10 +85,18 @@ if ( empty( $error ) && $http->hasPostVariable( 'SaveButton' ) )
         foreach ( $synonyms as $synonym )
         {
             $synonym->setAttribute( 'parent_id', $newParentID );
+            if( !$newParentVisible )
+            {
+                $synonym->setInvisible( true );
+            }
             $synonym->store();
         }
 
         $tag->setAttribute( 'parent_id', $newParentID );
+        if( !$newParentVisible )
+        {
+            $tag->setInvisible( true );
+        }
         $tag->store();
 
         /* Extended Hook */

--- a/modules/tags/treemenu.php
+++ b/modules/tags/treemenu.php
@@ -75,6 +75,7 @@ foreach ( $children as $child )
 
     eZURI::transformURI( $childResponse['url'] );
     $childResponse['modified']                  = (int) $child->attribute( 'modified' );
+    $childResponse['hidden']                    = $child->attribute( 'hidden' );
     $response['children'][]                     = $childResponse;
 }
 

--- a/settings/eztags.ini
+++ b/settings/eztags.ini
@@ -1,5 +1,11 @@
 #?ini charset="utf-8"?
 
+[VisibilitySettings]
+# Switch it off in frontend and on in backend
+# Commented out in order not to override value set in extensions siteaccess ini file
+# Defaults to enabled if not set
+#ShowHiddenTags=enabled
+
 [GeneralSettings]
 # Used to define which prefix will tag URLs have.
 # Useful if you don't like tags/view part of tag URL

--- a/settings/eztags.ini
+++ b/settings/eztags.ini
@@ -60,3 +60,6 @@ ReindexWhenDelayedIndexingDisabled=disabled
 # When disabled, synonym tags are replaced by their main tag in attribute metadata
 # Useful for faceting with ezfind
 IndexSynonyms=enabled
+
+# When enabled hidden tags are indexed as well
+IndexHidden=disabled

--- a/share/db_schema.dba
+++ b/share/db_schema.dba
@@ -74,6 +74,13 @@ $schema = array (
         'not_null' => '1',
         'default' => 0,
       ),
+      'hidden' =>
+      array(
+          'length' => 1,
+          'type' => 'int',
+          'not_null' => '1',
+          'default' => 0,
+      ),
     ),
     'indexes' =>
     array (
@@ -109,6 +116,14 @@ $schema = array (
         array (
           0 => 'remote_id',
         ),
+      ),
+      'eztags_hidden' =>
+      array (
+          'type' => 'non-unique',
+          'fields' =>
+          array (
+              0 => 'hidden',
+          ),
       ),
     ),
   ),

--- a/sql/mysql/schema.sql
+++ b/sql/mysql/schema.sql
@@ -9,10 +9,12 @@ CREATE TABLE `eztags` (
   `remote_id` varchar(100) NOT NULL default '',
   `main_language_id` int(11) NOT NULL default '0',
   `language_mask` int(11) NOT NULL default '0',
+  `hidden` int(1) NOT NULL DEFAULT '0',
   PRIMARY KEY ( `id` ),
   KEY `eztags_keyword` ( `keyword` ),
   KEY `eztags_keyword_id` ( `keyword`, `id` ),
-  UNIQUE KEY `eztags_remote_id` ( `remote_id` )
+  UNIQUE KEY `eztags_remote_id` ( `remote_id` ),
+  KEY `eztags_hidden` (`hidden`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `eztags_attribute_link` (

--- a/translations/cro-HR/translation.ts
+++ b/translations/cro-HR/translation.ts
@@ -352,6 +352,34 @@
         <source>Use the main language if there is no prioritized translation.</source>
         <translation>Koristi glavni prijevod ako nema prioritiziranog prijevoda.</translation>
     </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide/Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden by superior</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>extension/eztags/tags/search</name>

--- a/translations/dut-NL/translation.ts
+++ b/translations/dut-NL/translation.ts
@@ -352,6 +352,34 @@
         <source>Use the main language if there is no prioritized translation.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide/Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden by superior</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>extension/eztags/tags/search</name>

--- a/translations/esl-ES/translation.ts
+++ b/translations/esl-ES/translation.ts
@@ -352,6 +352,34 @@
         <source>Use the main language if there is no prioritized translation.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide/Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden by superior</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>extension/eztags/tags/search</name>

--- a/translations/fre-FR/translation.ts
+++ b/translations/fre-FR/translation.ts
@@ -352,6 +352,34 @@
         <source>Use the main language if there is no prioritized translation.</source>
         <translation>Utiliser la langue principale s&apos;il n&apos;existe pas de traduction prioritaire.</translation>
     </message>
+    <message>
+        <source>Hide</source>
+        <translation>Cacher</translation>
+    </message>
+    <message>
+        <source>Unhide</source>
+        <translation>Révéler</translation>
+    </message>
+    <message>
+        <source>Hide/Unhide</source>
+        <translation>Cacher / Révéler</translation>
+    </message>
+    <message>
+        <source>Visibility</source>
+        <translation>Visibilité</translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation>Visible</translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation>Caché</translation>
+    </message>
+    <message>
+        <source>Hidden by superior</source>
+        <translation>Caché par un tag supérieur</translation>
+    </message>
 </context>
 <context>
     <name>extension/eztags/tags/search</name>

--- a/translations/ger-DE/translation.ts
+++ b/translations/ger-DE/translation.ts
@@ -352,6 +352,34 @@
         <source>Use the main language if there is no prioritized translation.</source>
         <translation>Hauptsprache benutzen wenn keine prioritisierte Übersetzung existiert.</translation>
     </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide/Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden by superior</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>extension/eztags/tags/search</name>

--- a/translations/ita-IT/translation.ts
+++ b/translations/ita-IT/translation.ts
@@ -352,6 +352,34 @@
         <source>Use the main language if there is no prioritized translation.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide/Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden by superior</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>extension/eztags/tags/search</name>

--- a/translations/pol-PL/translation.ts
+++ b/translations/pol-PL/translation.ts
@@ -352,6 +352,34 @@
         <source>Use the main language if there is no prioritized translation.</source>
         <translation>Użyj głównego języka jeżeli nie ma ustalonych priorytetów tłumaczeń.</translation>
     </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide/Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden by superior</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>extension/eztags/tags/search</name>

--- a/translations/untranslated/translation.ts
+++ b/translations/untranslated/translation.ts
@@ -352,6 +352,34 @@
         <source>Use the main language if there is no prioritized translation.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide/Unhide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden by superior</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>extension/eztags/tags/search</name>

--- a/update/database/mysql/2.0/eztags-dbupdate-2.0-to-2.0.1.sql
+++ b/update/database/mysql/2.0/eztags-dbupdate-2.0-to-2.0.1.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `eztags` ADD COLUMN `hidden` int(1) NOT NULL DEFAULT '0' AFTER `language_mask`;
+ALTER TABLE `eztags` ADD KEY `eztags_hidden` (`hidden`);


### PR DESCRIPTION
Hi,
here I come again with my bloody feature ;)

I took my code from pull request #39 and revamped it for version 2. I guess it'll be easier for you to review it this way and add it to the next release instead of creating an intermediary v1.

Hidden tags are now filtered only in the low level `eZtagsObject::fetchCustomCondsSQL` method. 

I began to work on passing an ignoreVisibility flag from method to method but it quickly became messy and created a few logic problems (for example, what to do when getting parent attribute of an invisible tag object ?). 

Do you think that flag is really necessary ?

You can check it out on https://github.com/Heliopsis-HQ/eztags/commit/3c92ac061e7ae520a10d969c3cfff20ca6da31ba


Thanks

Ben