### PR TITLE
Multilanguage indexing

### DIFF
--- a/classes/ezfsolrdocumentfieldeztags.php
+++ b/classes/ezfsolrdocumentfieldeztags.php
@@ -50,15 +50,15 @@ class ezfSolrDocumentFieldeZTags extends ezfSolrDocumentFieldBase
                 {
                     //get keyword in content's locale
                     $keyword = $tag->getKeyword( $contentObjectAttribute->attribute( 'language_code' ) );
-                    if( !$keyword )
+                    if ( !$keyword )
                     {
                         //fall back to main language
                         $mainLanguage = eZContentLanguage::fetch( $tag->attribute( 'main_language_id') );
-                        if( $mainLanguage instanceof eZContentLanguage )
+                        if ( $mainLanguage instanceof eZContentLanguage )
                             $keyword = $tag->getKeyword( $mainLanguage->attribute( 'locale' ) );
                     }
 
-                    if( $keyword )
+                    if ( $keyword )
                     {
                         $tagIDs[] = (int) $tag->attribute( 'id' );
                         $keywords[] = $keyword;

--- a/datatypes/eztags/eztagstype.php
+++ b/datatypes/eztags/eztagstype.php
@@ -358,14 +358,14 @@ class eZTagsType extends eZDataType
             if ( $tag instanceof eZTagsObject )
             {
                 $keyword = $tag->getKeyword( $attribute->attribute( 'language_code' ) );
-                if( !$keyword )
+                if ( !$keyword )
                 {
                     //fall back to main language
                     $mainLanguage = eZContentLanguage::fetch( $tag->attribute( 'main_language_id') );
-                    if( $mainLanguage instanceof eZContentLanguage )
+                    if ( $mainLanguage instanceof eZContentLanguage )
                         $keyword = $tag->getKeyword( $mainLanguage->attribute( 'locale' ) );
                 }
-                if( $keyword )
+                if ( $keyword )
                     $keywords[] = $keyword;
             }
         }


### PR DESCRIPTION
Hi,
another couple changes to multilanguage version : 
- current implementation uses current language when indexing tag attributes which is not correct when indexing an english content in a french backend.
- The always available flag wasn't used when fetching a translation in a particular locale, I added a fallback to main translation when required translation does not exist and tag is flagged as always available
