### PR TITLE
Added $keyword variable to fetches in eztags

### DIFF
--- a/modules/tags/eztagsfunctioncollection.php
+++ b/modules/tags/eztagsfunctioncollection.php
@@ -70,7 +70,7 @@ class eZTagsFunctionCollection
      * @param bool $includeSynonyms
      * @return array
      */
-    static public function fetchTagTree( $parentTagID, $sortBy, $offset, $limit, $depth, $depthOperator, $includeSynonyms )
+    static public function fetchTagTree( $parentTagID, $sortBy, $offset, $limit, $depth, $depthOperator, $includeSynonyms, $keyword = false )
     {
         if ( !is_numeric( $parentTagID ) || (int) $parentTagID < 0 )
             return array( 'result' => false );
@@ -84,6 +84,11 @@ class eZTagsFunctionCollection
         {
             $params['Depth'] = $depth;
             $params['DepthOperator'] = $depthOperator;
+        }
+        
+        if ( $keyword !== false )
+        {
+            $params['Keyword'] = $keyword;
         }
 
         $tags = eZTagsObject::subTreeByTagID( $params, $parentTagID );
@@ -101,7 +106,7 @@ class eZTagsFunctionCollection
      * @param bool $includeSynonyms
      * @return integer
      */
-    static public function fetchTagTreeCount( $parentTagID, $depth, $depthOperator, $includeSynonyms )
+    static public function fetchTagTreeCount( $parentTagID, $depth, $depthOperator, $includeSynonyms, $keyword = false )
     {
         if ( !is_numeric( $parentTagID ) || (int) $parentTagID < 0 )
             return array( 'result' => 0 );
@@ -112,6 +117,11 @@ class eZTagsFunctionCollection
         {
             $params['Depth'] = $depth;
             $params['DepthOperator'] = $depthOperator;
+        }
+        
+        if ( $keyword !== false )
+        {
+            $params['Keyword'] = $keyword;
         }
 
         $tagsCount = eZTagsObject::subTreeCountByTagID( $params, $parentTagID );

--- a/modules/tags/function_definition.php
+++ b/modules/tags/function_definition.php
@@ -60,6 +60,10 @@ $FunctionList['list'] = array( 'name'            => 'list',
                                                            array( 'name'     => 'include_synonyms',
                                                                   'type'     => 'bool',
                                                                   'required' => false,
+                                                                  'default'  => false ),
+                                                           array( 'name'     => 'keyword',
+                                                                  'type'     => 'string',
+                                                                  'required' => false,
                                                                   'default'  => false ) ) );
 
 $FunctionList['list_count'] = array( 'name'            => 'list_count',
@@ -80,6 +84,10 @@ $FunctionList['list_count'] = array( 'name'            => 'list_count',
                                                                         'default'  => 'le' ),
                                                                  array( 'name'     => 'include_synonyms',
                                                                         'type'     => 'bool',
+                                                                        'required' => false,
+                                                                        'default'  => false ),
+                                                                 array( 'name'     => 'keyword',
+                                                                        'type'     => 'string',
                                                                         'required' => false,
                                                                         'default'  => false ) ) );
 
@@ -114,6 +122,10 @@ $FunctionList['tree'] = array( 'name'            => 'tree',
                                                            array( 'name'     => 'include_synonyms',
                                                                   'type'     => 'bool',
                                                                   'required' => false,
+                                                                  'default'  => false ),
+                                                           array( 'name'     => 'keyword',
+                                                                  'type'     => 'string',
+                                                                  'required' => false,
                                                                   'default'  => false ) ) );
 
 $FunctionList['tree_count'] = array( 'name'            => 'tree_count',
@@ -135,7 +147,11 @@ $FunctionList['tree_count'] = array( 'name'            => 'tree_count',
                                                                  array( 'name'     => 'include_synonyms',
                                                                         'type'     => 'bool',
                                                                         'required' => false,
-                                                                        'default'  => false ) ) );
+                                                                        'default'  => false ),
+                                                                 array( 'name'     => 'keyword',
+                                                                        'type'     => 'string',
+                                                                        'default'  => false,
+                                                                        'required' => false ) ) );
 
 $FunctionList['latest_tags'] = array( 'name'            => 'latest_tags',
                                       'operation_types' => array( 'read' ),


### PR DESCRIPTION
This pull request is for the changes of the fetch functions in eztags which makes it possible for a user to fetch a tree or a list of tags and their respective counts using the $keyword variable which filters the results by the keyword required. The $keyword variable is not a required variable making it possible for the fetch functions to retain their previous functionality.