### PR TITLE
EZP-22527: Use INNER JOIN notation for extended attribute filter

### DIFF
--- a/classes/eztagsattributefilter.php
+++ b/classes/eztagsattributefilter.php
@@ -42,12 +42,12 @@ class eZTagsAttributeFilter
                 }
             }
 
-            $returnArray['tables'] = ", eztags_attribute_link i1 ";
+            $returnArray['tables'] = " INNER JOIN eztags_attribute_link i1 ON (i1.object_id = ezcontentobject.id AND i1.objectattribute_version = ezcontentobject.current_version)";
 
             $db = eZDB::instance();
             $dbString = $db->generateSQLINStatement( $tagIDsArray, 'i1.keyword_id', false, true, 'int' );
 
-            $returnArray['joins'] = " $dbString AND i1.object_id = ezcontentobject.id AND i1.objectattribute_version = ezcontentobject.current_version AND ";
+            $returnArray['joins'] = " $dbString AND ";
         }
 
         return $returnArray;


### PR DESCRIPTION
Following EZP-19158 , the extended attribute filter of eZTags does not yet use the INNER JOIN notation.

This causes SQL errors when the extended attribute filter is used before other filters in fetches.

https://jira.ez.no/browse/EZP-22527
