### PR TITLE
Json is malformed when keyword is a float

### DIFF
--- a/modules/tags/treemenu.php
+++ b/modules/tags/treemenu.php
@@ -31,7 +31,7 @@ function arrayToJSON( $array )
             {
                 $value = arrayToJSON( $value );
             }
-            else if ( !is_numeric( $value ) or $key == 'name' )
+            else if ( !is_numeric( $value ) or $key == 'name' or $key == 'keyword' )
             {
                 $value = '"' . washJS( $value ) . '"';
             }


### PR DESCRIPTION
When the keyword is a float the json is malformed and can not be parsed by the java script