### PR TITLE
Limit the number of tags displayed

### DIFF
--- a/classes/ezjscoretagssuggest.php
+++ b/classes/ezjscoretagssuggest.php
@@ -34,7 +34,8 @@ class ezjscoreTagsSuggest extends ezjscServerFunctions
 
             $params['path_string'] = array( 'like', '%/' . $subTreeLimit . '/%' );
         }
-        $tags = eZTagsObject::fetchList( $params );
+        $eztagsINI = eZINI::instance('eztags.ini');
+        $tags = eZTagsObject::fetchList( $params, $eztagsINI->variable('TreeMenu','Limit') );
 
         $returnArray = array();
         $returnArray['status']  = 'success';

--- a/modules/tags/treemenu.php
+++ b/modules/tags/treemenu.php
@@ -109,13 +109,14 @@ if ( !( $tag instanceof eZTagsObject || $TagID == 0 ) )
 }
 else
 {
-    $children = eZTagsObject::fetchByParentID( $tagID );
+    $allChildrenCount = eZTagsObject::childrenCountByParentID( $tagID );
+    $children = eZTagsObject::fetchByParentID( $tagID, 0, $eztagsINI->variable('TreeMenu','Limit') );
 
     $response = array();
     $response['error_code']     = 0;
     $response['id']             = $tagID;
     $response['parent_id']      = ( $tag instanceof eZTagsObject ) ? (int) $tag->attribute( 'parent_id' ) : -1;
-    $response['children_count'] = count( $children );
+    $response['children_count'] = $allChildrenCount;
     $response['children']       = array();
 
     foreach ( $children as $child )

--- a/settings/eztags.ini
+++ b/settings/eztags.ini
@@ -27,6 +27,9 @@ AutoopenCurrentTag=enabled
 # If disabled only current path will be opened.
 MenuPersistence=enabled
 
+# Limit the number of tags displayed in the menu
+Limit=0
+
 [Icons]
 Default=empty.png
 # Customizing tree icon on eztag administration tab.


### PR DESCRIPTION
When there are too many tags javascript menu displays put too much time to process the list to display it, so I added the possibility of limiting the number of displayed tags.