### PR TITLE
EZP-24138: Fix eZ Tags missing schema sql required for multilanguage postgresql support

### DIFF
--- a/sql/postgresql/schema.sql
+++ b/sql/postgresql/schema.sql
@@ -1,0 +1,58 @@
+CREATE SEQUENCE eztags_s;
+CREATE TABLE eztags (
+   id integer DEFAULT nextval('eztags_s'::text) NOT NULL,
+   parent_id integer not null default 0,
+   main_tag_id integer not null default 0,
+   keyword varchar(255) NOT NULL default '',
+   depth integer NOT NULL default 1,
+   path_string varchar(255) NOT NULL default '',
+   modified integer NOT NULL default 0,
+   remote_id varchar(100) NOT NULL default '',
+   main_language_id integer not null default 0,
+   language_mask integer not null default 0,
+   PRIMARY KEY (id),
+   CONSTRAINT remote_id UNIQUE  (remote_id)
+);
+CREATE INDEX eztags_keyword ON eztags (
+   keyword
+);
+CREATE INDEX eztags_keyword_id ON eztags (
+   keyword,
+   id
+);
+ 
+CREATE SEQUENCE eztags_attribute_link_s;
+CREATE TABLE eztags_attribute_link (
+   id integer DEFAULT nextval('eztags_attribute_link_s'::text) NOT NULL,
+   keyword_id integer not null default 0,
+   objectattribute_id integer not null default 0,
+   objectattribute_version integer not null default 0,
+   object_id integer not null default 0,
+   priority integer not null default 0,
+   PRIMARY KEY (id)
+);
+CREATE INDEX eztags_attr_link_keyword_id ON eztags_attribute_link (
+   keyword_id
+);
+CREATE INDEX eztags_attr_link_kid_oaid_oav ON eztags_attribute_link (
+   keyword_id,
+   objectattribute_id,
+   objectattribute_version
+);
+CREATE INDEX eztags_attr_link_kid_oid ON eztags_attribute_link (
+   keyword_id,
+   object_id
+);
+CREATE INDEX eztags_attr_link_oaid_oav ON eztags_attribute_link (
+   objectattribute_id,
+   objectattribute_version
+);
+ 
+CREATE TABLE eztags_keyword (
+   keyword_id integer not null default 0,
+   language_id integer not null default 0,
+   keyword varchar(255) NOT NULL default '',
+   locale varchar(255) NOT NULL default '',
+   status integer not null default 0,
+   PRIMARY KEY (keyword_id, locale)
+);


### PR DESCRIPTION
Hello,

We noticed that the activity on PR #90 had gone stale for some time and since we have already been very active in that PR we wanted to step up and try to complete the work required.

This is the related issue ticket: https://jira.ez.no/browse/EZP-24138

This PR is specifically for the multilanguage branch. We have submitted another PR #91 for the required changes to the master branch as well.

This PR comes from the following share.ez.no forum conversation: http://share.ez.no/forums/install-configuration/migration-from-mysql-to-postgresql#comment85594

Please let us know what you think!

Cheers,
Brookins Consulting