### PR TITLE
Fix suggest feature when there are multiple existing selected tags

### DIFF
--- a/classes/eztagsobject.php
+++ b/classes/eztagsobject.php
@@ -553,7 +553,7 @@ class eZTagsObject extends eZPersistentObject
     {
         $cond = $customCond = null;
 
-        if ( strpos( $keyword, '*' ) !== false )
+        if ( is_string( $keyword ) && strpos( $keyword, '*' ) !== false )
             $customCond = self::generateCustomCondition( $keyword );
         else
             $cond = array( 'keyword' => $keyword );


### PR DESCRIPTION
This commit broke the "Suggested tags" feature since the selected tags are passed as an array:
https://github.com/ezsystems/eztags/commit/c40d09f50bca815a67f8d71068e2256fe4bdc71a#diff-d1fd49b25a0f4cb14579782aff6fe587