### PR TITLE
jQuery selector bug fixed

### DIFF
--- a/design/admin2/javascript/jquery.eztagschildren.js
+++ b/design/admin2/javascript/jquery.eztagschildren.js
@@ -185,7 +185,7 @@
         /* More actions button */
 
         var moreActionsButtonAction = function( type, args, item ) {
-            if ( $( '#eztags-tag-children-table input[name=SelectedIDArray[]]:checked' ).length == 0 )
+            if ( $( '#eztags-tag-children-table input[name=\"SelectedIDArray[]\"]:checked' ).length == 0 )
                 return;
 
             if ( item.value == 0 && settings.permissions.remove ) {
@@ -237,7 +237,7 @@
 
         //  enable 'more actions' when rows are checked
         moreActionsButton.getMenu().subscribe('beforeShow', function () {
-            if ( $( '#eztags-tag-children-table input[name=SelectedIDArray[]]:checked' ).length == 0 ) {
+            if ( $( '#eztags-tag-children-table input[name=\"SelectedIDArray[]\"]:checked' ).length == 0 ) {
                 this.clearContent();
                 this.addItems( noMoreActionsButtonActions );
                 this.render();


### PR DESCRIPTION
There was a problem with 'More Actions' buttons. User was unable to delete or move more selected tags, as more action buttons were not shown. Issue was with square brackets in a string used as jQuery selector that had to be escaped. Fixed it with putting 'name' attribute value in quotes.