### PR TITLE
Trigger an additional dropdown list on multi-selects when there is an existing selection

### DIFF
--- a/design/standard/javascript/jquery.eztags.select.js
+++ b/design/standard/javascript/jquery.eztags.select.js
@@ -24,8 +24,10 @@
           $.each(this.tags.items, function(i, tag){
             console.log(tag.name);
             self.append_select(tag);
-            self.update_selects();
           });
+          self.$selects = self.$('.selects');
+          self.should_append_new_select();
+          self.update_selects();
         }else{
           self.append_select();
         }


### PR DESCRIPTION
Before this fix, on a multi-select with an existing selection, you have to empty the selection and re-select it in order to get another dropdown.

Simple illustration: https://dl.dropboxusercontent.com/u/23142/temp/coverage_type_missing_tags.png

I'm not confident this is the final solution, but it's a starting point for discussion.