### PR TITLE
Added a new extended attribute filter that allows tag path filtering

### DIFF
--- a/classes/eztagstreeattributefilter.php
+++ b/classes/eztagstreeattributefilter.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * eZTagsTreeAttributeFilter class implements TagsTreeAttributeFilter extended attribute
+ *
+ */
+class eZTagsTreeAttributeFilter
+{
+    /**
+     * Creates and returns SQL parts used in fetch functions
+     *
+     * @return array
+     */
+    function createSqlParts( $params )
+    {
+        $returnArray = array( 'tables' => '', 'joins'  => '', 'columns' => '' );
+        
+        if ( isset( $params['parent_tag_id'] ) )
+        {
+            if ( is_array( $params['parent_tag_id'] ) )
+            {
+                $tagIDArray = $params['parent_tag_id'];
+            }
+            else if ( (int)$params['parent_tag_id'] > 0 )
+            {
+                $tagIDArray = array( $params['parent_tag_id'] );
+            }
+            else
+            {
+                return $returnArray;
+            }
+            $suffix = '/%';
+            if( isset( $params['exclude_parent'] ) && $params['exclude_parent'] )
+            {
+                $suffix = '/%/%';
+            }
+            $returnArray['tables'] = "  INNER JOIN eztags_attribute_link i1 ON (i1.object_id = ezcontentobject.id AND i1.objectattribute_version = ezcontentobject.current_version)
+                                        INNER JOIN eztags i2 ON (i1.keyword_id = i2.id)
+                                        INNER JOIN eztags_keyword i3 ON (i2.id = i3.keyword_id)";
+            $db = eZDB::instance();
+            $dbString = '( ';
+            $dbStringArray = array();
+            if( isset( $params['type'] ) && strtolower( $params['type'] ) == 'and' )
+            {
+                foreach( $tagIDArray as $tagID )
+                {
+                     $dbStringArray[] = "EXISTS (
+                                        SELECT 1
+                                        FROM
+                                            eztags_attribute_link j1,
+                                            ezcontentobject j2,
+                                            eztags j3
+                                        WHERE j3.path_string LIKE \"%/" . $db->escapeString( $tagID . $suffix ) ."\"" .
+                                        " AND j1.object_id = j2.id
+                                        AND j2.id = ezcontentobject.id
+                                        AND j1.objectattribute_version = j2.current_version
+                                        AND j3.id = j1.keyword_id )";
+                }
+                $dbString .= implode(' AND ', $dbStringArray);
+            }
+            else
+            {
+                foreach( $tagIDArray as $tagID )
+                {
+                    $dbStringArray[] = ' i2.path_string LIKE "%/' . $db->escapeString( $tagID . $suffix ) .'"';
+                }
+                $dbString .= implode(' OR ', $dbStringArray);
+            }
+            
+            $dbString .= ' )';
+            if ( isset( $params['language'] ) )
+            {
+                $language = $params['language'];
+                if ( !is_array( $language ) )
+                    $language = array( $language );
+                eZContentLanguage::setPrioritizedLanguages( $language );
+            }
+
+
+            $returnArray['joins'] = " $dbString
+                                  AND " . eZContentLanguage::languagesSQLFilter( 'i2' ) . " AND " .
+                                  eZContentLanguage::sqlFilter( 'i3', 'i2' ) . " AND ";
+
+            if ( isset( $params['language'] ) )
+                eZContentLanguage::clearPrioritizedLanguages();
+        }
+
+        return $returnArray;
+    }
+}
+
+?>

--- a/settings/extendedattributefilter.ini.append.php
+++ b/settings/extendedattributefilter.ini.append.php
@@ -11,4 +11,8 @@ MethodName=createAndFilterSqlParts
 [TagsAttributeAndMultipleFilter]
 ClassName=eZTagsAttributeFilter
 MethodName=createAndMultipleFilterSqlParts
+
+[TagsTreeAttributeFilter]
+ClassName=eZTagsTreeAttributeFilter
+MethodName=createSqlParts
  */


### PR DESCRIPTION
I have created a new extended attribute filter, so it should be possible to filter by tag path string.
Example:
```
    {def $hash_params=hash(
                            'parent_node_id', 2
                            , 'extended_attribute_filter', hash(
                                'id', 'TagsTreeAttributeFilter',
                                'params', hash(
                                    'parent_tag_id', $tag_id_array,
                                    'exclude_parent', true(),
                                   
                                )
                            )
                            , 'sort_by', array( 'published', false() )
                      )
         $children_extra=fetch( 'content', 'tree', $hash_params )}
```
path_string: a single path string or an array of path strings.
Optional params:
exclude_parent: boolean.
language: example: eng-US
type: 'and' or 'or', defaults to 'or'.
path_string is an array, or a single tag path_string, you can build like:

The parent_tag_id is an array of tag ids.