### PR TITLE
Tie top menu link display to dashboard permissions

### DIFF
--- a/settings/menu.ini.append.php
+++ b/settings/menu.ini.append.php
@@ -22,5 +22,5 @@ Shown[edit]=true
 Shown[navigation]=true
 Shown[browse]=true
 
-PolicyList[]=tags/read
+PolicyList[]=tags/dashboard
 */


### PR DESCRIPTION
As pointed out by a client, users without the necessary permissions click on the eZ Tags tab and then get confused because they can't actually see the dashboard.