### PR TITLE
Respect the subtree limit when returning tag suggestions

### DIFF
--- a/classes/ezjsctags.php
+++ b/classes/ezjsctags.php
@@ -103,7 +103,7 @@ class ezjscTags extends ezjscServerFunctions
 
         return self::generateOutput(
             array( 'id' => array( $tagsToSuggest ) ),
-            0,
+            $http->postVariable( 'subtree_limit', 0 ),
             false,
             $http->postVariable( 'locale', '' )
         );


### PR DESCRIPTION
The Ajax call is sending the tags subtree ID properly, but the server-side function needs to actually use it. Otherwise you end up with suggestions from the wrong tree.