### PR TITLE
eZ Tags auto-complete: match before or after the input phrase

### DIFF
--- a/classes/ezjsctags.php
+++ b/classes/ezjsctags.php
@@ -19,15 +19,22 @@ class ezjscTags extends ezjscServerFunctions
         $http = eZHTTPTool::instance();
 
         $searchString = trim( $http->postVariable( 'search_string' ), '' );
+        $broadMatch = eZINI::instance('eztags.ini')->variable( 'GeneralSettings', 'BroadMatchAutoComplete' )  == 'enabled';
+
         if ( empty( $searchString ) )
             return array( 'status' => 'success', 'message' => '', 'tags' => array() );
 
         // Initialize transformation system
         $trans = eZCharTransform::instance();
         $searchString = $trans->transformByGroup( $http->postVariable( 'search_string' ), 'lowercase' );
+        $searchStringParam = $searchString . '%';
+        if ($broadMatch)
+        {
+            $searchStringParam = '%' . $searchStringParam;
+        }
 
         return self::generateOutput(
-            array( 'LOWER( eztags_keyword.keyword )' => array( 'like', $searchString . '%' ) ),
+            array( 'LOWER( eztags_keyword.keyword )' => array( 'like', $searchStringParam ) ),
             $http->postVariable( 'subtree_limit', 0 ),
             $http->postVariable( 'hide_root_tag', '0' ),
             $http->postVariable( 'locale', '' )

--- a/settings/eztags.ini
+++ b/settings/eztags.ini
@@ -25,6 +25,12 @@ TagCloudOverSolr=enabled
 # interface display when searching for tags in content edit
 MaxResults=24
 
+# Defines if auto suggest should use wild card search to match tags that
+# contains the string in the middle of the tag instead of checking if the tag
+# starts with the string
+# Default is disabled, so it will only match tags that start with the string
+BroadMatchAutoComplete=disabled
+
 [TreeMenu]
 # enabled/disabled
 ToolTips=enabled


### PR DESCRIPTION
This pull request makes it possible for the user to control when the auto complete field should fetch tags matching the beginning of the string or if the it should contain the string in the middle of the tag name.

This is specially useful when we have thousands of tags and we don't want to create more, so we need also to fetch and verify if there are tags with the current string in the middle of its name.

For example, right now if we search for "test", it will return tags like "test 1" and "test 2", but not "this is a test", with this commit it makes it possible to control the search so it also returns "this is a test".

The commit creates a checkbox, "Broad Match", in the attribute edit view, if checked the behavior changes to match the specified case.

@peterkeung