### PR TITLE
Fixed data parameter names in tree and treeconfig eZJSCore methods

### DIFF
--- a/classes/ezjsctags.php
+++ b/classes/ezjsctags.php
@@ -237,7 +237,7 @@ class ezjscTags extends ezjscServerFunctions
                 'a_attr' => array(
                     'data-id' => (int) $rootTag->attribute( 'id' ),
                     'data-name' => $rootTag->attribute( 'keyword' ),
-                    'data-parentId' => (int) $rootTag->attribute( 'parent_id' ),
+                    'data-parent_id' => (int) $rootTag->attribute( 'parent_id' ),
                     'data-locale' => $rootTag->attribute( 'current_language' )
                 ),
                 'state' => array(
@@ -317,7 +317,7 @@ class ezjscTags extends ezjscServerFunctions
                 'a_attr' => array(
                     'data-id' => (int) $child->attribute( 'id' ),
                     'data-name' => $child->attribute( 'keyword' ),
-                    'data-parentId' => (int) $child->attribute( 'parent_id' ),
+                    'data-parent_id' => (int) $child->attribute( 'parent_id' ),
                     'data-locale' => $child->attribute( 'current_language' )
                 )
             );


### PR DESCRIPTION
Description: when a Tree view edit mode is enabled, data-parentId passed in response creates data-parentid field in markup and tag.parentid property in Javascript Tag objects, while all the methods are expecting parent_id property. When tag is added in attribute, empty parent tag ID value will be appended to attribute post field 'ContentObjectAttribute_eztags_data_text2_'. This will result with validation error if user tries to store draft or publish the object. On second try, however, storing draft or publishing object would be successfully completed since the selected tags would be refetched and data_text2 field would receive correct parent id list.