### PR TITLE
Italicize synonyms in tag results

### DIFF
--- a/classes/ezjsctags.php
+++ b/classes/ezjsctags.php
@@ -417,6 +417,7 @@ class ezjscTags extends ezjscServerFunctions
             $returnArrayChild['parent_name'] = $tag->hasParent( true ) ? $tag->getParent( true )->attribute( 'keyword' ) : '';
             $returnArrayChild['name']        = $tag->attribute( 'keyword' );
             $returnArrayChild['id']          = $tag->attribute( 'id' );
+            $returnArrayChild['main_tag_id'] = $tag->attribute( 'main_tag_id' );
             $returnArrayChild['locale']      = $tag->attribute( 'current_language' );
             $returnArray['tags'][]           = $returnArrayChild;
         }

--- a/design/standard/javascript/jquery.eztags.js
+++ b/design/standard/javascript/jquery.eztags.js
@@ -288,7 +288,7 @@
       ],
       suggestedItem: ['<li class="js-suggested-item" data-cid="<%= tag.cid %>" title="<%=tr.clickAddThisTag%>"><img src="<%=tag.flagSrc %>"/><%=tag.name%></li>'],
       selectedItem: ['<li data-cid="<%= tag.cid %>"><img src="<%=tag.flagSrc %>" /><%=tag.name%><a href="#" class="js-tags-remove" title="<%=tr.removeTag%>">&times;</a></li>'],
-      autocompleteItem: ['<div data-cid="<%= tag.cid %>" class="js-autocomplete-item resultItem"><a href="#"><img src="<%=tag.flagSrc %>"/><%=tag.name%><span><%= tag.parent_name %></span></a></div>'],
+      autocompleteItem: ['<div data-cid="<%= tag.cid %>" class="js-autocomplete-item resultItem<%= tag.main_tag_id !== "0" ? " itemSynonim" : "" %>"><a href="#"><img src="<%=tag.flagSrc %>"/><%=tag.name%><span><%= tag.parent_name %></span></a></div>'],
     }
   };
 

--- a/design/standard/stylesheets/tagssuggest.css
+++ b/design/standard/stylesheets/tagssuggest.css
@@ -49,6 +49,9 @@ position:         absolute;
     height:auto;
     cursor:pointer;
 }
+.jsonSuggestResults .resultItem.itemSynonim {
+    font-style: italic;
+}
 .jsonSuggestResults .resultItem a {padding:5px;}
 .jsonSuggestResults .resultItem a img{margin-right:5px;}
 


### PR DESCRIPTION
Italicize the synonyms in the tag results in the auto-complete view in edit mode in order to make it easier for editors to differentiate synonyms from main tags.
