### PR TITLE
Fix Issue #114: error when suggesting tags similar to current tags

### DIFF
--- a/classes/ezjsctags.php
+++ b/classes/ezjsctags.php
@@ -62,8 +62,8 @@ class ezjscTags extends ezjscServerFunctions
         $tagIDs = $http->postVariable( 'tag_ids', '' );
         if ( empty( $tagIDs ) )
             return array( 'status' => 'success', 'message' => '', 'tags' => array() );
-        if(is_array($tagIDs)) {
-            $tagIDs = implode('|#', $tagIDs);
+        if ( is_array( $tagIDs ) ) {
+            $tagIDs = implode( '|#', $tagIDs );
         }
 
         $tagIDs = array_values( array_unique( explode( '|#', $tagIDs ) ) );

--- a/classes/ezjsctags.php
+++ b/classes/ezjsctags.php
@@ -62,6 +62,9 @@ class ezjscTags extends ezjscServerFunctions
         $tagIDs = $http->postVariable( 'tag_ids', '' );
         if ( empty( $tagIDs ) )
             return array( 'status' => 'success', 'message' => '', 'tags' => array() );
+        if(is_array($tagIDs)) {
+            $tagIDs = implode('|#', $tagIDs);
+        }
 
         $tagIDs = array_values( array_unique( explode( '|#', $tagIDs ) ) );
 


### PR DESCRIPTION
removes a message from the error log and makes tag suggestion more pertinent